### PR TITLE
backoff bug fix

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/skytap/ChangeConfigurationStateStep.java
+++ b/src/main/java/org/jenkinsci/plugins/skytap/ChangeConfigurationStateStep.java
@@ -49,11 +49,11 @@ public class ChangeConfigurationStateStep extends SkytapAction {
 
 	// number of times it will poll Skytap to see if correct runstate has been
 	// reached
-	private static final int NUMBER_OF_RETRIES = 7;
+	private static final int NUMBER_OF_RETRIES = 10;
 
 	// base retry interval - on every retry it will double the current value,
 	// backing off
-	private static final int BASE_RETRY_INTERVAL_SECONDS = 20;
+	private static final int BASE_RETRY_INTERVAL_SECONDS = 10;
 
 	// these vars will be initialized when the step is run
 
@@ -168,7 +168,7 @@ public class ChangeConfigurationStateStep extends SkytapAction {
 				// to busy runstates needs to be reconsidered
 				// but a change to a simple exponential backoff
 				// will do for now-- jchenry
-				int sleepTime = (2^i*BASE_RETRY_INTERVAL_SECONDS);
+				int sleepTime = (int)Math.pow(2,i)*BASE_RETRY_INTERVAL_SECONDS;
 
 				JenkinsLogger.log("Sleeping for " + sleepTime + " seconds.");
 


### PR DESCRIPTION
there is an issue with current implementation of exponential backoff waiting for configuration state change, this was found when starting up an skytap environment which take some time to bring up. in java language `^` operator is not used for exponential operation but instead is used for XOR operations. this fix uses Math.pow operation to fix the logic it was intended to be implemented according with documentation. 

finally i would like to say all the unit test were successful and also this modification was tested on our production environment with total success.